### PR TITLE
make shell scripts portable

### DIFF
--- a/first-setup.sh
+++ b/first-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 # A simple file to run all instructions from the README
 ## this should be run in the root of the repository

--- a/parse_hlds.sh
+++ b/parse_hlds.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # args = map(lambda arg: arg if x[0] in "/-" else pwd+arg, sys.argv[1:])

--- a/populate-db.sh
+++ b/populate-db.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 cd "$(dirname "$0")/app"


### PR DESCRIPTION
The current shell scripts call `/bin/bash`. This won't work on certain
systems (`nixos` for example :eyes: ).

By switching to `/usr/bin/env bash` these scripts become portable. As
long as `bash` environment is present on a system, the scripts will
work.