### PR TITLE
Use a more common unicode arrow that can be found in more fonts

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -243,9 +243,9 @@ details summary {
 }
 details summary:before {
 	font-style: normal;
-	content: "⯈";
+	content: "▸";
 	padding-right: 0.4em;
 }
 details[open] summary:before {
-	content: "⯆";
+	content: "▾";
 }


### PR DESCRIPTION
Original character was: ⯆ (https://www.compart.com/en/unicode/U+2BC6)
New character is: ▾ (https://www.compart.com/en/unicode/U+25BE)